### PR TITLE
Add premiumAIProcedure + OpenRouter managed-key path

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -83,6 +83,11 @@ SENTRY_ENVIRONMENT=""
 # Performance traces sample rate (0.0 disables tracing). Keep low in production.
 SENTRY_TRACES_SAMPLE_RATE="0"
 
+# --- AI Providers ---
+# Server-side OpenRouter key used when FLAG_AI_MODE is "managed" or "both".
+# Required in production when FLAG_AI_MODE is not "byo". Get one at https://openrouter.ai.
+OPENROUTER_API_KEY=""
+
 # --- Feature Flags ---
 # This flag bypasses the check that the endpoint to fetch data for the printing of PDFs `getByIdForPrinter`, is only accessible from the server.
 # Useful for when you want to debug the /printer/{resumeId} route to quickly take a peek at the page that is sent to the printer.
@@ -98,9 +103,15 @@ FLAG_DISABLE_EMAIL_AUTH="false"
 # This is useful if you are using a machine with limited resources, like a Raspberry Pi.
 FLAG_DISABLE_IMAGE_PROCESSING="false"
 
-# This flag disables all AI features (PDF/DOCX parsing, chat, tailoring) at the API layer.
-# Defaults to "true" until premium AI billing is implemented. Set to "false" to expose AI endpoints.
-FLAG_DISABLE_AI="true"
+# Emergency kill-switch for all AI features (PDF/DOCX parsing, chat, tailoring) at the API layer.
+# Default is "false". Flip to "true" to instantly disable all AI endpoints.
+FLAG_DISABLE_AI="false"
+
+# Selects how AI requests are credentialed:
+#   "byo"     — every user supplies their own provider/key (self-host default)
+#   "managed" — server uses OPENROUTER_API_KEY; gated to plan === "premium"
+#   "both"    — premium users get managed; free users fall back to BYO
+FLAG_AI_MODE="byo"
 
 # --- Others ---
 # Google Cloud API Key (optional)

--- a/README.md
+++ b/README.md
@@ -64,7 +64,8 @@ Before deploying to production, verify the following:
 - [ ] `AUTH_SECRET` is set to a unique value generated with `openssl rand -hex 32` (the app refuses to boot with the placeholder).
 - [ ] SMTP is configured (`SMTP_HOST`, `SMTP_USER`, `SMTP_PASS`, `SMTP_FROM`), or `EMAIL_TRANSPORT="console"` is set explicitly to opt in to console-logged emails.
 - [ ] `FLAG_DEBUG_PRINTER="false"` (or unset) in the production environment.
-- [ ] `FLAG_DISABLE_AI="true"` until the premium AI flow is implemented.
+- [ ] `FLAG_AI_MODE` is set explicitly: `"byo"` for self-host, `"managed"` for the hosted Premium tier, `"both"` for mixed. The app refuses to boot in production when `FLAG_AI_MODE != "byo"` and `OPENROUTER_API_KEY` is unset.
+- [ ] `FLAG_DISABLE_AI="false"` (or unset). Flip to `"true"` only as an emergency kill-switch.
 - [ ] Automated database backups are configured and a restore has been tested.
 - [ ] Browserless (or alternative Chrome service) is reachable from the app and has health checks.
 - [ ] HTTPS is enforced (`force_https = true` in `fly.toml`).

--- a/src/dialogs/resume/import.tsx
+++ b/src/dialogs/resume/import.tsx
@@ -83,7 +83,7 @@ function fileToBase64(file: File): Promise<string> {
 
 export function ImportResumeDialog(_: DialogProps<"resume.import">) {
   const navigate = useNavigate();
-  const { enabled: isAIEnabled, provider, model, apiKey, baseURL } = useAIStore();
+  const { enabled: isAIEnabled, mode: aiMode, provider, model, apiKey, baseURL } = useAIStore();
   const closeDialog = useDialogStore((state) => state.closeDialog);
 
   const prevTypeRef = useRef<string>("");
@@ -150,6 +150,8 @@ export function ImportResumeDialog(_: DialogProps<"resume.import">) {
         data = importer.parse(json);
       }
 
+      const credentials = aiMode === "managed" ? { model: model || undefined } : { provider, model, apiKey, baseURL };
+
       if (values.type === "pdf") {
         if (!isAIEnabled)
           throw new Error(t`This feature requires AI Integration to be enabled. Please enable it in the settings.`);
@@ -158,10 +160,7 @@ export function ImportResumeDialog(_: DialogProps<"resume.import">) {
         const base64 = await fileToBase64(values.file);
 
         data = await client.ai.parsePdf({
-          provider,
-          model,
-          apiKey,
-          baseURL,
+          ...credentials,
           file: { name: values.file.name, data: base64 },
         });
       }
@@ -179,10 +178,7 @@ export function ImportResumeDialog(_: DialogProps<"resume.import">) {
             : ("application/vnd.openxmlformats-officedocument.wordprocessingml.document" as const);
 
         data = await client.ai.parseDocx({
-          provider,
-          model,
-          apiKey,
-          baseURL,
+          ...credentials,
           mediaType,
           file: { name: values.file.name, data: base64 },
         });

--- a/src/integrations/ai/store.ts
+++ b/src/integrations/ai/store.ts
@@ -8,8 +8,13 @@ export type AIProvider = "vercel-ai-gateway" | "openai" | "gemini" | "anthropic"
 
 type TestStatus = "unverified" | "success" | "failure";
 
+// Local preference for which credential path to use. Authoritative dispatch
+// happens server-side based on FLAG_AI_MODE + plan; this is only a UX hint.
+export type AIMode = "byo" | "managed";
+
 type AIStoreState = {
   enabled: boolean;
+  mode: AIMode;
   provider: AIProvider;
   model: string;
   apiKey: string;
@@ -20,6 +25,7 @@ type AIStoreState = {
 type AIStoreActions = {
   canEnable: () => boolean;
   setEnabled: (value: boolean) => void;
+  setMode: (value: AIMode) => void;
   set: (fn: (draft: WritableDraft<AIStoreState>) => void) => void;
   reset: () => void;
 };
@@ -28,6 +34,7 @@ type AIStore = AIStoreState & AIStoreActions;
 
 const initialState: AIStoreState = {
   enabled: false,
+  mode: "byo",
   provider: "openai",
   model: "",
   apiKey: "",
@@ -63,7 +70,8 @@ export const useAIStore = create<AIStore>()(
       },
       reset: () => set(() => initialState),
       canEnable: () => {
-        const { testStatus } = get();
+        const { mode, testStatus } = get();
+        if (mode === "managed") return true;
         return testStatus === "success";
       },
       setEnabled: (value: boolean) => {
@@ -73,12 +81,24 @@ export const useAIStore = create<AIStore>()(
           draft.enabled = value;
         });
       },
+      setMode: (value: AIMode) => {
+        set((draft) => {
+          if (draft.mode === value) return;
+          draft.mode = value;
+          // Switching mode invalidates the BYO test result; let the user re-enable.
+          draft.enabled = value === "managed";
+          if (value === "byo") {
+            draft.testStatus = "unverified";
+          }
+        });
+      },
     })),
     {
       name: "ai-store",
       storage: createJSONStorage(() => localStorage),
       partialize: (state) => ({
         enabled: state.enabled,
+        mode: state.mode,
         provider: state.provider,
         model: state.model,
         apiKey: state.apiKey,

--- a/src/integrations/orpc/context.ts
+++ b/src/integrations/orpc/context.ts
@@ -10,6 +10,7 @@ import { env } from "@/utils/env";
 import { auth, verifyOAuthToken } from "../auth/config";
 import { db } from "../drizzle/client";
 import { user } from "../drizzle/schema";
+import { isPremiumUser } from "./services/ai";
 
 interface ORPCContext {
   locale: Locale;
@@ -86,16 +87,45 @@ export const protectedProcedure = publicProcedure.use(async ({ context, next }) 
 });
 
 /**
- * Authenticated procedure for AI endpoints. Rejects requests when AI features
- * are globally disabled via FLAG_DISABLE_AI. This is the choke point that will
- * be replaced with a per-user premium check once subscriptions are wired up.
+ * Authenticated procedure for AI endpoints. Decides per-request whether to
+ * route through BYO (user-supplied credentials) or managed (server's
+ * OPENROUTER_API_KEY, gated to plan === "premium") based on FLAG_AI_MODE
+ * and the user's plan. Adds `aiMode` to context so handlers can resolve
+ * credentials via `resolveAICredentials`.
  */
-export const gatedAIProcedure = protectedProcedure.use(async ({ context, next }) => {
+export const aiProcedure = protectedProcedure.use(async ({ context, next }) => {
   if (env.FLAG_DISABLE_AI) {
     throw new ORPCError("FORBIDDEN", { message: "AI features are currently disabled" });
   }
 
-  return next({ context });
+  const flagMode = env.FLAG_AI_MODE;
+  let aiMode: "byo" | "managed";
+
+  if (flagMode === "byo") {
+    aiMode = "byo";
+  } else {
+    const isPremium = await isPremiumUser(context.user.id);
+
+    if (flagMode === "managed") {
+      if (!isPremium) {
+        throw new ORPCError("FORBIDDEN", {
+          message: "AI features require a Premium plan.",
+        });
+      }
+      aiMode = "managed";
+    } else {
+      // "both" — premium gets managed, free falls back to BYO
+      aiMode = isPremium ? "managed" : "byo";
+    }
+  }
+
+  if (aiMode === "managed" && !env.OPENROUTER_API_KEY) {
+    throw new ORPCError("INTERNAL_SERVER_ERROR", {
+      message: "Managed AI is not configured on this server.",
+    });
+  }
+
+  return next({ context: { ...context, aiMode } });
 });
 
 /**

--- a/src/integrations/orpc/router/ai.ts
+++ b/src/integrations/orpc/router/ai.ts
@@ -7,14 +7,51 @@ import z, { flattenError, ZodError } from "zod";
 import { jobResultSchema } from "@/schema/jobs";
 import { type ResumeData, resumeDataSchema } from "@/schema/resume/data";
 import { tailorOutputSchema } from "@/schema/tailor";
+import { env } from "@/utils/env";
 
-import { gatedAIProcedure } from "../context";
-import { aiCredentialsSchema, aiProviderSchema, aiService, fileInputSchema } from "../services/ai";
-
-type AIProvider = z.infer<typeof aiProviderSchema>;
+import { aiProcedure, protectedProcedure } from "../context";
+import {
+  type AICredentialsInput,
+  aiCredentialsSchema,
+  aiService,
+  DEFAULT_MANAGED_MODEL,
+  fileInputSchema,
+  isPremiumUser,
+  resolveAICredentials,
+} from "../services/ai";
 
 export const aiRouter = {
-  testConnection: gatedAIProcedure
+  getConfig: protectedProcedure
+    .route({
+      method: "GET",
+      path: "/ai/config",
+      tags: ["AI"],
+      operationId: "getAiConfig",
+      summary: "Get AI configuration for the current user",
+      description:
+        "Returns whether AI is enabled on this instance, the credential mode (BYO vs. managed), whether a managed key is configured, and whether the current user has Premium access. Requires authentication.",
+      successDescription: "The current AI configuration for this user.",
+    })
+    .output(
+      z.object({
+        enabled: z.boolean().describe("False when FLAG_DISABLE_AI is set."),
+        mode: z
+          .enum(["byo", "managed", "both"])
+          .describe('How AI requests are credentialed on the server. "managed" and "both" require Premium.'),
+        hasManagedKey: z.boolean().describe("Whether OPENROUTER_API_KEY is configured on the server."),
+        isPremium: z.boolean().describe("Whether the current user can use managed AI."),
+        defaultManagedModel: z.string().describe("Default model identifier used when managed mode requests omit one."),
+      }),
+    )
+    .handler(async ({ context }) => ({
+      enabled: !env.FLAG_DISABLE_AI,
+      mode: env.FLAG_AI_MODE,
+      hasManagedKey: Boolean(env.OPENROUTER_API_KEY),
+      isPremium: await isPremiumUser(context.user.id),
+      defaultManagedModel: DEFAULT_MANAGED_MODEL,
+    })),
+
+  testConnection: aiProcedure
     .route({
       method: "POST",
       path: "/ai/test-connection",
@@ -22,26 +59,20 @@ export const aiRouter = {
       operationId: "testAiConnection",
       summary: "Test AI provider connection",
       description:
-        "Validates the connection to an AI provider by sending a simple test prompt. Requires the provider type, model name, API key, and an optional base URL. Supported providers: OpenAI, Anthropic, Google Gemini, Ollama, and Vercel AI Gateway. Requires authentication.",
+        "Validates the AI provider connection. In BYO mode, supply provider/model/apiKey/baseURL; in managed mode (Premium), credentials are sourced from the server. Requires authentication.",
       successDescription: "The AI provider connection was successful.",
     })
-    .input(
-      z.object({
-        provider: aiProviderSchema,
-        model: z.string(),
-        apiKey: z.string(),
-        baseURL: z.string(),
-      }),
-    )
+    .input(aiCredentialsSchema)
     .errors({
       BAD_GATEWAY: {
         message: "The AI provider returned an error or is unreachable.",
         status: 502,
       },
     })
-    .handler(async ({ input }) => {
+    .handler(async ({ context, input }) => {
       try {
-        return await aiService.testConnection(input);
+        const credentials = resolveAICredentials(context.aiMode, input);
+        return await aiService.testConnection(credentials);
       } catch (error) {
         if (error instanceof AISDKError || error instanceof OllamaError) {
           throw new ORPCError("BAD_GATEWAY", { message: error.message });
@@ -51,7 +82,7 @@ export const aiRouter = {
       }
     }),
 
-  parsePdf: gatedAIProcedure
+  parsePdf: aiProcedure
     .route({
       method: "POST",
       path: "/ai/parse-pdf",
@@ -59,7 +90,7 @@ export const aiRouter = {
       operationId: "parseResumePdf",
       summary: "Parse a PDF file into resume data",
       description:
-        "Extracts structured resume data from a PDF file using the specified AI provider. The file should be sent as a base64-encoded string along with AI provider credentials. Returns a complete ResumeData object. Requires authentication.",
+        "Extracts structured resume data from a PDF file using the configured AI provider. The file should be sent as a base64-encoded string. AI credentials are required in BYO mode and ignored in managed mode. Returns a complete ResumeData object. Requires authentication.",
       successDescription: "The PDF was successfully parsed into structured resume data.",
     })
     .input(
@@ -78,9 +109,10 @@ export const aiRouter = {
         status: 400,
       },
     })
-    .handler(async ({ input }): Promise<ResumeData> => {
+    .handler(async ({ context, input }): Promise<ResumeData> => {
       try {
-        return await aiService.parsePdf(input);
+        const credentials = resolveAICredentials(context.aiMode, input);
+        return await aiService.parsePdf({ ...credentials, file: input.file });
       } catch (error) {
         if (error instanceof AISDKError) {
           throw new ORPCError("BAD_GATEWAY", { message: error.message });
@@ -96,7 +128,7 @@ export const aiRouter = {
       }
     }),
 
-  parseDocx: gatedAIProcedure
+  parseDocx: aiProcedure
     .route({
       method: "POST",
       path: "/ai/parse-docx",
@@ -104,7 +136,7 @@ export const aiRouter = {
       operationId: "parseResumeDocx",
       summary: "Parse a DOCX file into resume data",
       description:
-        "Extracts structured resume data from a DOCX or DOC file using the specified AI provider. The file should be sent as a base64-encoded string along with AI provider credentials and the document's media type. Returns a complete ResumeData object. Requires authentication.",
+        "Extracts structured resume data from a DOCX or DOC file using the configured AI provider. The file should be sent as a base64-encoded string along with its media type. AI credentials are required in BYO mode and ignored in managed mode. Returns a complete ResumeData object. Requires authentication.",
       successDescription: "The DOCX was successfully parsed into structured resume data.",
     })
     .input(
@@ -127,9 +159,10 @@ export const aiRouter = {
         status: 400,
       },
     })
-    .handler(async ({ input }) => {
+    .handler(async ({ context, input }) => {
       try {
-        return await aiService.parseDocx(input);
+        const credentials = resolveAICredentials(context.aiMode, input);
+        return await aiService.parseDocx({ ...credentials, file: input.file, mediaType: input.mediaType });
       } catch (error) {
         if (error instanceof AISDKError) {
           throw new ORPCError("BAD_GATEWAY", { message: error.message });
@@ -146,7 +179,7 @@ export const aiRouter = {
       }
     }),
 
-  chat: gatedAIProcedure
+  chat: aiProcedure
     .route({
       method: "POST",
       path: "/ai/chat",
@@ -154,21 +187,20 @@ export const aiRouter = {
       operationId: "aiChat",
       summary: "Chat with AI to modify resume",
       description:
-        "Streams a chat response from the configured AI provider. The LLM can call the patch_resume tool to generate JSON Patch operations that modify the resume. Requires authentication and AI provider credentials.",
+        "Streams a chat response from the configured AI provider. The LLM can call the patch_resume tool to generate JSON Patch operations that modify the resume. AI credentials are required in BYO mode and ignored in managed mode. Requires authentication.",
     })
     .input(
-      type<{
-        provider: AIProvider;
-        model: string;
-        apiKey: string;
-        baseURL: string;
-        messages: UIMessage[];
-        resumeData: ResumeData;
-      }>(),
+      type<
+        AICredentialsInput & {
+          messages: UIMessage[];
+          resumeData: ResumeData;
+        }
+      >(),
     )
-    .handler(async ({ input }) => {
+    .handler(async ({ context, input }) => {
       try {
-        return await aiService.chat(input);
+        const credentials = resolveAICredentials(context.aiMode, input);
+        return await aiService.chat({ ...credentials, messages: input.messages, resumeData: input.resumeData });
       } catch (error) {
         if (error instanceof AISDKError || error instanceof OllamaError) {
           throw new ORPCError("BAD_GATEWAY", { message: error.message });
@@ -178,7 +210,7 @@ export const aiRouter = {
       }
     }),
 
-  tailorResume: gatedAIProcedure
+  tailorResume: aiProcedure
     .route({
       method: "POST",
       path: "/ai/tailor-resume",
@@ -186,7 +218,7 @@ export const aiRouter = {
       operationId: "tailorResume",
       summary: "Auto-tailor resume for a job posting",
       description:
-        "Uses AI to automatically tailor a resume for a specific job posting. Rewrites the summary, adjusts experience descriptions, and curates skills for ATS optimization. Returns structured modifications as a simplified output object. Requires authentication and AI credentials.",
+        "Uses AI to automatically tailor a resume for a specific job posting. Rewrites the summary, adjusts experience descriptions, and curates skills for ATS optimization. Returns structured modifications as a simplified output object. AI credentials are required in BYO mode and ignored in managed mode. Requires authentication.",
       successDescription: "Structured tailoring output returned successfully.",
     })
     .input(
@@ -207,9 +239,10 @@ export const aiRouter = {
         status: 400,
       },
     })
-    .handler(async ({ input }) => {
+    .handler(async ({ context, input }) => {
       try {
-        return await aiService.tailorResume(input);
+        const credentials = resolveAICredentials(context.aiMode, input);
+        return await aiService.tailorResume({ ...credentials, resumeData: input.resumeData, job: input.job });
       } catch (error) {
         if (error instanceof AISDKError || error instanceof OllamaError) {
           throw new ORPCError("BAD_GATEWAY", { message: error.message });

--- a/src/integrations/orpc/services/ai.ts
+++ b/src/integrations/orpc/services/ai.ts
@@ -1,6 +1,7 @@
 import { createAnthropic } from "@ai-sdk/anthropic";
 import { createGoogleGenerativeAI } from "@ai-sdk/google";
 import { createOpenAI } from "@ai-sdk/openai";
+import { ORPCError } from "@orpc/client";
 import { streamToEventIterator } from "@orpc/server";
 import {
   convertToModelMessages,
@@ -13,6 +14,7 @@ import {
   type UIMessage,
 } from "ai";
 import { createOllama } from "ai-sdk-ollama";
+import { eq } from "drizzle-orm";
 import { jsonrepair } from "jsonrepair";
 import { match } from "ts-pattern";
 import z, { flattenError, ZodError } from "zod";
@@ -31,8 +33,11 @@ import {
   patchResumeDescription,
   patchResumeInputSchema,
 } from "@/integrations/ai/tools/patch-resume";
+import { db } from "@/integrations/drizzle/client";
+import { user } from "@/integrations/drizzle/schema";
 import { defaultResumeData, resumeDataSchema } from "@/schema/resume/data";
 import { type TailorOutput, tailorOutputSchema } from "@/schema/tailor";
+import { env } from "@/utils/env";
 import { isObject } from "@/utils/sanitize";
 
 const aiExtractionTemplate = {
@@ -289,19 +294,23 @@ function normalizeResumeDataForSchema(data: Record<string, unknown>) {
   return { ...data, sections: normalizedSections };
 }
 
-export const aiProviderSchema = z.enum(["ollama", "openai", "gemini", "anthropic", "vercel-ai-gateway"]);
+export const aiProviderSchema = z.enum(["ollama", "openai", "gemini", "anthropic", "vercel-ai-gateway", "openrouter"]);
 
 type AIProvider = z.infer<typeof aiProviderSchema>;
 
-type GetModelInput = {
+export type ResolvedAICredentials = {
   provider: AIProvider;
   model: string;
   apiKey: string;
   baseURL: string;
 };
 
+type GetModelInput = ResolvedAICredentials;
+
 const MAX_AI_FILE_BYTES = 10 * 1024 * 1024; // 10MB
 const MAX_AI_FILE_BASE64_CHARS = Math.ceil((MAX_AI_FILE_BYTES * 4) / 3) + 4;
+
+export const OPENROUTER_BASE_URL = "https://openrouter.ai/api/v1";
 
 function getModel(input: GetModelInput) {
   const { provider, model, apiKey } = input;
@@ -313,22 +322,71 @@ function getModel(input: GetModelInput) {
     .with("anthropic", () => createAnthropic({ apiKey, baseURL }).languageModel(model))
     .with("vercel-ai-gateway", () => createGateway({ apiKey, baseURL }).languageModel(model))
     .with("gemini", () => createGoogleGenerativeAI({ apiKey, baseURL }).languageModel(model))
+    .with("openrouter", () => createOpenAI({ apiKey, baseURL: baseURL ?? OPENROUTER_BASE_URL }).chat(model))
     .exhaustive();
 }
 
+// BYO credentials sent from the client. All fields optional so managed-mode
+// requests (which omit them entirely) still pass validation.
 export const aiCredentialsSchema = z.object({
-  provider: aiProviderSchema,
-  model: z.string(),
-  apiKey: z.string(),
-  baseURL: z.string(),
+  provider: aiProviderSchema.optional(),
+  model: z.string().optional(),
+  apiKey: z.string().optional(),
+  baseURL: z.string().optional(),
 });
+
+export type AICredentialsInput = z.infer<typeof aiCredentialsSchema>;
+
+export type AIMode = "byo" | "managed";
+
+// Cheap multimodal default used when managed-mode requests don't specify a model.
+export const DEFAULT_MANAGED_MODEL = "google/gemini-2.0-flash-001";
+
+export async function isPremiumUser(userId: string): Promise<boolean> {
+  const [row] = await db
+    .select({ plan: user.plan, planExpiresAt: user.planExpiresAt })
+    .from(user)
+    .where(eq(user.id, userId))
+    .limit(1);
+  if (!row || row.plan !== "premium") return false;
+  if (row.planExpiresAt && row.planExpiresAt < new Date()) return false;
+  return true;
+}
+
+export function resolveAICredentials(aiMode: AIMode, input: AICredentialsInput): ResolvedAICredentials {
+  if (aiMode === "managed") {
+    if (!env.OPENROUTER_API_KEY) {
+      throw new ORPCError("INTERNAL_SERVER_ERROR", {
+        message: "Managed AI is not configured on this server.",
+      });
+    }
+    return {
+      provider: "openrouter",
+      model: input.model || DEFAULT_MANAGED_MODEL,
+      apiKey: env.OPENROUTER_API_KEY,
+      baseURL: OPENROUTER_BASE_URL,
+    };
+  }
+
+  if (!input.provider || !input.apiKey || !input.model) {
+    throw new ORPCError("BAD_REQUEST", {
+      message: "AI provider, model, and API key are required.",
+    });
+  }
+  return {
+    provider: input.provider,
+    model: input.model,
+    apiKey: input.apiKey,
+    baseURL: input.baseURL ?? "",
+  };
+}
 
 export const fileInputSchema = z.object({
   name: z.string(),
   data: z.string().max(MAX_AI_FILE_BASE64_CHARS, "File is too large. Maximum size is 10MB."), // base64 encoded
 });
 
-type TestConnectionInput = z.infer<typeof aiCredentialsSchema>;
+type TestConnectionInput = ResolvedAICredentials;
 
 async function testConnection(input: TestConnectionInput): Promise<boolean> {
   const RESPONSE_OK = "1";
@@ -342,7 +400,7 @@ async function testConnection(input: TestConnectionInput): Promise<boolean> {
   return result.output === RESPONSE_OK;
 }
 
-type ParsePdfInput = z.infer<typeof aiCredentialsSchema> & {
+type ParsePdfInput = ResolvedAICredentials & {
   file: z.infer<typeof fileInputSchema>;
 };
 
@@ -391,7 +449,7 @@ async function parsePdf(input: ParsePdfInput): Promise<ResumeData> {
   return parseAndValidateResumeJson(result.text);
 }
 
-type ParseDocxInput = z.infer<typeof aiCredentialsSchema> & {
+type ParseDocxInput = ResolvedAICredentials & {
   file: z.infer<typeof fileInputSchema>;
   mediaType: "application/msword" | "application/vnd.openxmlformats-officedocument.wordprocessingml.document";
 };
@@ -416,7 +474,7 @@ function buildChatSystemPrompt(resumeData: ResumeData): string {
   return chatSystemPromptTemplate.replace("{{RESUME_DATA}}", JSON.stringify(resumeData, null, 2));
 }
 
-type ChatInput = z.infer<typeof aiCredentialsSchema> & {
+type ChatInput = ResolvedAICredentials & {
   messages: UIMessage[];
   resumeData: ResumeData;
 };
@@ -459,7 +517,7 @@ function buildTailorSystemPrompt(resumeData: ResumeData, job: JobResult): string
     .replace("{{JOB_SKILLS}}", (job.job_required_skills || []).join(", ") || "None specified.");
 }
 
-type TailorResumeInput = z.infer<typeof aiCredentialsSchema> & {
+type TailorResumeInput = ResolvedAICredentials & {
   resumeData: ResumeData;
   job: JobResult;
 };

--- a/src/routes/_home/-sections/faq.tsx
+++ b/src/routes/_home/-sections/faq.tsx
@@ -31,8 +31,8 @@ const getFaqItems = (): FAQItemData[] => [
     answer: (
       <Trans>
         Sim, o Currículos IA está disponível em português do Brasil e em outros idiomas. Você pode escolher o idioma nas
-        configurações ou usar o seletor de idioma no topo da página. Se não encontrar o seu idioma, ou quiser melhorar as
-        traduções existentes, você pode{" "}
+        configurações ou usar o seletor de idioma no topo da página. Se não encontrar o seu idioma, ou quiser melhorar
+        as traduções existentes, você pode{" "}
         <a
           href={crowdinUrl}
           target="_blank"

--- a/src/routes/_home/-sections/templates.tsx
+++ b/src/routes/_home/-sections/templates.tsx
@@ -7,8 +7,8 @@ import { useEffect, useMemo, useState } from "react";
 
 import type { TemplateMetadata } from "@/dialogs/resume/template/data";
 
-import { templates } from "@/dialogs/resume/template/data";
 import { Button } from "@/components/ui/button";
+import { templates } from "@/dialogs/resume/template/data";
 
 type TemplateItemProps = {
   metadata: TemplateMetadata;

--- a/src/routes/_home/-sections/testimonials.tsx
+++ b/src/routes/_home/-sections/testimonials.tsx
@@ -148,12 +148,7 @@ export function Testimonials() {
         </p>
       </motion.div>
 
-      <div
-        className="relative"
-        role="region"
-        aria-label={t`Depoimentos de usuários`}
-        aria-live="off"
-      >
+      <div className="relative" role="region" aria-label={t`Depoimentos de usuários`} aria-live="off">
         {/* Left fade */}
         <div className="pointer-events-none absolute inset-s-0 top-0 bottom-0 z-10 w-16 bg-linear-to-r from-background to-transparent sm:w-24 md:w-32 lg:w-48" />
 

--- a/src/routes/dashboard/job-search/-components/tailor-dialog.tsx
+++ b/src/routes/dashboard/job-search/-components/tailor-dialog.tsx
@@ -47,6 +47,7 @@ export function TailorDialog({ job, open, onOpenChange }: Props) {
   const [selectedSkills, setSelectedSkills] = useState<Set<number>>(new Set());
 
   const aiEnabled = useAIStore((s) => s.enabled);
+  const aiMode = useAIStore((s) => s.mode);
   const aiProvider = useAIStore((s) => s.provider);
   const aiModel = useAIStore((s) => s.model);
   const aiApiKey = useAIStore((s) => s.apiKey);
@@ -106,11 +107,13 @@ export function TailorDialog({ job, open, onOpenChange }: Props) {
       const resume = await client.resume.getById({ id: newResumeId });
 
       // Step 3: Call AI tailor endpoint
+      const aiCredentials =
+        aiMode === "managed"
+          ? { model: aiModel || undefined }
+          : { provider: aiProvider, model: aiModel, apiKey: aiApiKey, baseURL: aiBaseURL };
+
       const tailorOutput = await client.ai.tailorResume({
-        provider: aiProvider,
-        model: aiModel,
-        apiKey: aiApiKey,
-        baseURL: aiBaseURL,
+        ...aiCredentials,
         resumeData: resume.data,
         job,
       });

--- a/src/routes/dashboard/settings/ai.tsx
+++ b/src/routes/dashboard/settings/ai.tsx
@@ -1,7 +1,7 @@
 import { t } from "@lingui/core/macro";
 import { Trans } from "@lingui/react/macro";
-import { BrainIcon, CheckCircleIcon, InfoIcon, XCircleIcon } from "@phosphor-icons/react";
-import { useMutation } from "@tanstack/react-query";
+import { BrainIcon, CheckCircleIcon, CrownIcon, InfoIcon, XCircleIcon } from "@phosphor-icons/react";
+import { useMutation, useQuery } from "@tanstack/react-query";
 import { createFileRoute } from "@tanstack/react-router";
 import { motion } from "motion/react";
 import { useMemo } from "react";
@@ -57,6 +57,102 @@ const providerOptions: (ComboboxOption<AIProvider> & { defaultBaseURL: string })
     defaultBaseURL: "https://generativelanguage.googleapis.com/v1beta",
   },
 ];
+
+function ManagedAIPanel({
+  isPremium,
+  hasManagedKey,
+  defaultModel,
+}: {
+  isPremium: boolean;
+  hasManagedKey: boolean;
+  defaultModel: string;
+}) {
+  const model = useAIStore((s) => s.model);
+  const setStore = useAIStore((s) => s.set);
+
+  if (!hasManagedKey) {
+    return (
+      <div className="flex items-start gap-4 rounded-md border bg-popover p-6">
+        <div className="rounded-md bg-muted p-2.5">
+          <InfoIcon className="text-muted-foreground" size={24} />
+        </div>
+        <div className="flex-1 space-y-2">
+          <h3 className="font-semibold">
+            <Trans>Managed AI not configured</Trans>
+          </h3>
+          <p className="leading-relaxed text-muted-foreground">
+            <Trans>
+              This instance is set to managed mode but no managed API key is configured. Contact your administrator.
+            </Trans>
+          </p>
+        </div>
+      </div>
+    );
+  }
+
+  if (!isPremium) {
+    return (
+      <div className="flex items-start gap-4 rounded-md border bg-popover p-6">
+        <div className="rounded-md bg-primary/10 p-2.5">
+          <CrownIcon className="text-primary" size={24} />
+        </div>
+        <div className="flex-1 space-y-2">
+          <h3 className="font-semibold">
+            <Trans>Premium AI is not enabled on your account</Trans>
+          </h3>
+          <p className="leading-relaxed text-muted-foreground">
+            <Trans>Subscribe to Premium to use Currículos IA's managed AI without bringing your own API key.</Trans>
+          </p>
+        </div>
+      </div>
+    );
+  }
+
+  return (
+    <div className="space-y-4">
+      <div className="flex items-start gap-4 rounded-md border bg-popover p-6">
+        <div className="rounded-md bg-primary/10 p-2.5">
+          <CrownIcon className="text-primary" size={24} />
+        </div>
+        <div className="flex-1 space-y-2">
+          <h3 className="font-semibold">
+            <Trans>Managed AI is active</Trans>
+          </h3>
+          <p className="leading-relaxed text-muted-foreground">
+            <Trans>Your AI requests are routed through Currículos IA's managed key. No further setup required.</Trans>
+          </p>
+        </div>
+      </div>
+
+      <div className="flex flex-col gap-y-2">
+        <Label htmlFor="ai-managed-model">
+          <Trans>Model (optional)</Trans>
+        </Label>
+        <Input
+          id="ai-managed-model"
+          name="ai-managed-model"
+          type="text"
+          value={model}
+          onChange={(e) =>
+            setStore((draft) => {
+              draft.model = e.target.value;
+            })
+          }
+          placeholder={defaultModel}
+          autoCorrect="off"
+          autoComplete="off"
+          spellCheck="false"
+          autoCapitalize="off"
+        />
+        <p className="text-xs text-muted-foreground">
+          <Trans>
+            Leave blank to use the default. Any OpenRouter model identifier works (e.g., openai/gpt-4o-mini).
+          </Trans>
+        </p>
+      </div>
+    </div>
+  );
+}
 
 function AIForm() {
   const { set, model, apiKey, baseURL, provider, enabled, testStatus } = useAIStore();
@@ -209,6 +305,24 @@ function RouteComponent() {
   const enabled = useAIStore((state) => state.enabled);
   const canEnable = useAIStore((state) => state.canEnable());
   const setEnabled = useAIStore((state) => state.setEnabled);
+  const mode = useAIStore((state) => state.mode);
+  const setMode = useAIStore((state) => state.setMode);
+
+  const { data: config, isLoading: isConfigLoading } = useQuery(orpc.ai.getConfig.queryOptions());
+
+  const serverMode = config?.mode ?? "byo";
+  const canPickManaged = serverMode === "both" && Boolean(config?.hasManagedKey) && Boolean(config?.isPremium);
+
+  let effectiveMode: "byo" | "managed";
+  if (serverMode === "byo") {
+    effectiveMode = "byo";
+  } else if (serverMode === "managed") {
+    effectiveMode = "managed";
+  } else {
+    effectiveMode = canPickManaged && mode === "managed" ? "managed" : "byo";
+  }
+  const showByoForm = effectiveMode === "byo";
+  const showManagedPanel = effectiveMode === "managed";
 
   if (!isClient) return null;
 
@@ -237,28 +351,72 @@ function RouteComponent() {
 
             <p className="leading-relaxed text-muted-foreground">
               <Trans>
-                Everything entered here is stored locally on your browser. Your data is only sent to the server when
-                making a request to the AI provider, and is never stored or logged on our servers.
+                Bring-your-own-key credentials are stored only on your browser. Your data is sent to the AI provider
+                only when you make a request, and is never stored or logged on our servers.
               </Trans>
             </p>
           </div>
         </div>
 
+        {!isConfigLoading && config && !config.enabled && (
+          <div className="flex items-start gap-4 rounded-md border bg-popover p-6">
+            <div className="rounded-md bg-destructive/10 p-2.5">
+              <XCircleIcon className="text-destructive" size={24} />
+            </div>
+            <div className="flex-1 space-y-2">
+              <h3 className="font-semibold">
+                <Trans>AI is disabled on this instance</Trans>
+              </h3>
+              <p className="leading-relaxed text-muted-foreground">
+                <Trans>The administrator has disabled all AI features.</Trans>
+              </p>
+            </div>
+          </div>
+        )}
+
+        {canPickManaged && (
+          <>
+            <Separator />
+            <div className="flex items-center justify-between">
+              <Label htmlFor="ai-mode-toggle">
+                <Trans>Use managed AI (Premium)</Trans>
+              </Label>
+              <Switch
+                id="ai-mode-toggle"
+                checked={mode === "managed"}
+                onCheckedChange={(checked) => setMode(checked ? "managed" : "byo")}
+              />
+            </div>
+          </>
+        )}
+
         <Separator />
 
-        <div className="flex items-center justify-between">
-          <Label htmlFor="enable-ai">
-            <Trans>Enable AI Features</Trans>
-          </Label>
-          <Switch id="enable-ai" checked={enabled} disabled={!canEnable} onCheckedChange={setEnabled} />
-        </div>
+        {showManagedPanel && (
+          <ManagedAIPanel
+            isPremium={Boolean(config?.isPremium)}
+            hasManagedKey={Boolean(config?.hasManagedKey)}
+            defaultModel={config?.defaultManagedModel ?? ""}
+          />
+        )}
 
-        <p className={cn("flex items-center gap-x-2", enabled ? "text-success" : "text-destructive")}>
-          {enabled ? <CheckCircleIcon /> : <XCircleIcon />}
-          {enabled ? <Trans>Enabled</Trans> : <Trans>Disabled</Trans>}
-        </p>
+        {showByoForm && (
+          <>
+            <div className="flex items-center justify-between">
+              <Label htmlFor="enable-ai">
+                <Trans>Enable AI Features</Trans>
+              </Label>
+              <Switch id="enable-ai" checked={enabled} disabled={!canEnable} onCheckedChange={setEnabled} />
+            </div>
 
-        <AIForm />
+            <p className={cn("flex items-center gap-x-2", enabled ? "text-success" : "text-destructive")}>
+              {enabled ? <CheckCircleIcon /> : <XCircleIcon />}
+              {enabled ? <Trans>Enabled</Trans> : <Trans>Disabled</Trans>}
+            </p>
+
+            <AIForm />
+          </>
+        )}
       </motion.div>
     </div>
   );

--- a/src/utils/env.ts
+++ b/src/utils/env.ts
@@ -98,14 +98,27 @@ export const env = createEnv({
     SENTRY_ENVIRONMENT: z.string().min(1).optional(),
     SENTRY_TRACES_SAMPLE_RATE: z.coerce.number().min(0).max(1).default(0),
 
+    // AI providers
+    OPENROUTER_API_KEY: z.string().min(1).optional(),
+
     // Feature Flags
     FLAG_DEBUG_PRINTER: z.stringbool().default(false),
     FLAG_DISABLE_SIGNUPS: z.stringbool().default(false),
     FLAG_DISABLE_EMAIL_AUTH: z.stringbool().default(false),
     FLAG_DISABLE_IMAGE_PROCESSING: z.stringbool().default(false),
-    FLAG_DISABLE_AI: z.stringbool().default(true),
+    // Emergency kill-switch for all AI endpoints. Default off; set to "true" to disable.
+    FLAG_DISABLE_AI: z.stringbool().default(false),
+    // Selects how AI requests are credentialed.
+    //   "byo"     — every user supplies their own provider/key (self-host default)
+    //   "managed" — server uses OPENROUTER_API_KEY; gated to plan === "premium"
+    //   "both"    — premium users get managed; free users fall back to BYO
+    FLAG_AI_MODE: z.enum(["byo", "managed", "both"]).default("byo"),
   },
 });
+
+if (isProduction && env.FLAG_AI_MODE !== "byo" && !env.OPENROUTER_API_KEY) {
+  throw new Error(`FLAG_AI_MODE="${env.FLAG_AI_MODE}" requires OPENROUTER_API_KEY to be set in production.`);
+}
 
 if (isProduction && env.EMAIL_TRANSPORT === "smtp") {
   const missing = [


### PR DESCRIPTION
## Summary

PR-1 of the premium-rollout sequence (PR-1 → PR-2 → PR-4 → PR-3 → PR-5). Adds the server-side gating + OpenRouter routing that the rest of the rollout depends on, while keeping the existing self-host BYO path fully working.

- Splits AI gating into a dispatcher that decides per-request whether to use **BYO** credentials (sent from the client) or the server's **OPENROUTER_API_KEY** (gated on `plan === "premium"`), driven by a new `FLAG_AI_MODE` env (`byo` | `managed` | `both`, default `byo`).
- Adds `OPENROUTER_API_KEY` env + production-mode fail-fast when `FLAG_AI_MODE != "byo"` and the key is unset.
- Defaults `FLAG_DISABLE_AI` to `false`; documented as an emergency kill-switch in the README launch checklist.
- Extends `aiProviderSchema` with `"openrouter"` and routes it through `createOpenAI` against `https://openrouter.ai/api/v1` (OpenRouter is OpenAI-compatible — no new SDK).
- Replaces `gatedAIProcedure` with `aiProcedure` that resolves `aiMode` from env + user plan (one DB read for fresh plan state) and adds it to the oRPC context.
- New `ai.getConfig` endpoint exposing `{ enabled, mode, hasManagedKey, isPremium, defaultManagedModel }` so the client renders the right UI without leaking the server key.
- AI input credentials are now optional; new `resolveAICredentials(aiMode, input)` returns the right credentials based on dispatch (managed → OpenRouter, BYO → client-supplied, with `BAD_REQUEST` if BYO input is incomplete).
- Settings page now shows: managed-status card for Premium users, upgrade hint for free users when `managed`/`both` is enabled, and a toggle when `serverMode === "both"` and the user has Premium.

## What this **doesn't** do

- No usage cap yet (PR-2).
- No `ai.config` is wired to a Premium pricing page yet (PR-3).
- No Stripe integration (PR-3).
- No new managed-mode model picker (deferred — users can still type a model identifier).

## Test plan

- [x] `pnpm typecheck` — clean
- [x] `pnpm lint` — clean (one pre-existing unrelated warning in `templates.tsx`)
- [x] `pnpm fmt` — clean
- [x] `pnpm test --run` — 238/238 pass
- [ ] Manual: `FLAG_AI_MODE=byo` (default) — settings page works as before, `client.ai.parsePdf({ provider, model, apiKey, baseURL, file })` succeeds.
- [ ] Manual: `FLAG_AI_MODE=managed` + free user — `ai.parsePdf` returns `403 Forbidden` ("AI features require a Premium plan.").
- [ ] Manual: `FLAG_AI_MODE=managed` + manually-flipped `user.plan='premium'` in DB + `OPENROUTER_API_KEY` set — `ai.parsePdf` succeeds without sending credentials.
- [ ] Manual: `FLAG_AI_MODE=both` + premium user → settings shows the toggle; toggling to "managed" hides the BYO form.
- [ ] Manual: `NODE_ENV=production` + `FLAG_AI_MODE=managed` + missing `OPENROUTER_API_KEY` — app refuses to boot with a clear error.

## Risks called out

- `ORPCError("PAYMENT_REQUIRED")` may not have a 402 mapping in oRPC; using `FORBIDDEN` for now.
- Streaming `aiService.chat` will burn OpenRouter quota even if the user disconnects mid-stream — accepted for v1, will revisit with usage cap (PR-2).
- Default managed model pinned to `google/gemini-2.0-flash-001` — cheap + multimodal. Override via the model field on the settings page.


---
_Generated by [Claude Code](https://claude.ai/code/session_01WdEMN48LABAjoMvadUZBxF)_